### PR TITLE
Fix: solved problem with gh

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
 
     # Install dependencies
     - name: Set up Python 3.11
@@ -37,7 +37,7 @@ jobs:
     # execute:
     #   execute_notebooks: cache
     - name: cache executed notebooks
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       with:
         path: _build/.jupyter_cache
         key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
@@ -46,13 +46,13 @@ jobs:
     - name: Build the book
       run: |
         jupyter-book build .
-    # Upload the book's HTML as an artifact
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
-      with:
-        path: "_build/html"
 
-    # Deploy the book's HTML to GitHub Pages
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        name: github-pages
+        path: _build/html
+
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and deploying a Jekyll site. The most important changes include upgrading the versions of various actions used in the workflow.

Version upgrades in GitHub Actions workflow:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L24-R24): Updated `actions/checkout` from version `v3` to `v4.2.2`.
* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L40-R40): Updated `actions/cache` from version `v3` to `v4.2.0`.
* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L49-R58): Updated `actions/upload-pages-artifact` from version `v2` to `v3` and added `name` parameter for artifact.
* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L49-R58): Updated `actions/deploy-pages` from version `v2` to `v4`.